### PR TITLE
Fixed usage of deferred for promises

### DIFF
--- a/src/ArrivalTime.js
+++ b/src/ArrivalTime.js
@@ -13,8 +13,6 @@ function ArrivalTime (station, targets) {
     this.station = station;
 
     this.targets = this.tidyUp(targets);
-
-    this.deferred = Q.defer();
 }
 
 ArrivalTime.prototype.tidyUp = function(stations) {
@@ -40,7 +38,7 @@ ArrivalTime.prototype.getResults = function() {
         url = this.buildUrl(),
         results = [],
         targets = this.targets,
-        deferred = this.deferred;
+        deferred = Q.defer();
 
     jsdom.env(
         url,


### PR DESCRIPTION
I just fixed a bug, where the deferred/promise object is stored globally and so only contains results from the first request. The deferred has to be created for every request, because it can be only fulfilled one time.
